### PR TITLE
composerでpearのライブラリを追加する際のパス修正

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "include-path": [
-        "./"
+        "./",
+        "./vendor/pear/net_useragent_mobile/"
     ],
     "autoload": {
         "classmap": [


### PR DESCRIPTION
# 概要
pear.php.netが一時使用出来なかったため、composerからライブラリを入れるように現在しています。

その際にNet UserAgent Mobile内で自身のパスを通すようにしていないので、BEAR.Saturday側のcomposerで設定するように修正してみました。