### PR TITLE
composer.jsonにMDB2のパスを追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,8 @@
     "prefer-stable": true,
     "include-path": [
         "./",
-        "./vendor/pear/net_useragent_mobile/"
+        "./vendor/pear/net_useragent_mobile/",
+        "./vendor/pear/mdb2/"
     ],
     "autoload": {
         "classmap": [


### PR DESCRIPTION
MDB2内で自身のパスを通すようにしていないため、BEAR.Saturday側のcomposer.jsonで設定

（前回のNet UserAgent MobileのPRと同様の事象だと思います）